### PR TITLE
Fix rspec files load message time

### DIFF
--- a/lib/spring/commands/crystalball.rb
+++ b/lib/spring/commands/crystalball.rb
@@ -15,6 +15,11 @@ module Spring
         "crystalball"
       end
 
+      def call
+        ::RSpec.configuration.start_time = Time.now if defined?(::RSpec.configuration.start_time)
+        ::Crystalball::RSpec::Runner.invoke
+      end
+
       def setup
         ::Crystalball::RSpec::Runner.prepare
       end


### PR DESCRIPTION
Running crystalball multiple times with spring caused the `files took n.nnn seconds to load` part of RSpec output to be wrong.